### PR TITLE
[图书列表] 优化书籍封面点击体验

### DIFF
--- a/app/views/books/index.html.erb
+++ b/app/views/books/index.html.erb
@@ -10,13 +10,13 @@
         <div class="bg-white rounded-lg shadow-md hover:shadow-lg transition duration-200 overflow-hidden">
           <!-- 封面圖片 -->
           <% if book.cover_image.attached? %>
-            <div class="h-48 overflow-hidden">
+            <%= link_to book_path(book), class: "block h-48 overflow-hidden hover:opacity-90 transition duration-200" do %>
               <%= image_tag book.cover_image, class: "w-full h-full object-cover" %>
-            </div>
+            <% end %>
           <% else %>
-            <div class="h-48 bg-gray-100 flex items-center justify-center">
+            <%= link_to book_path(book), class: "block h-48 bg-gray-100 flex items-center justify-center hover:bg-gray-200 transition duration-200" do %>
               <span class="text-gray-400 text-4xl">📖</span>
-            </div>
+            <% end %>
           <% end %>
           
           <!-- 書籍資訊 -->
@@ -37,7 +37,6 @@
             <% end %>
             
             <div class="flex space-x-2">
-              <%= link_to "View", book_path(book), class: "bg-green-500 hover:bg-green-600 text-white text-sm font-medium py-1 px-3 rounded transition duration-200" %>
               <%= link_to "Edit", edit_book_path(book), class: "bg-yellow-500 hover:bg-yellow-600 text-white text-sm font-medium py-1 px-3 rounded transition duration-200" %>
               <%= link_to "Delete", book_path(book), method: :delete, 
                           confirm: "Are you sure you want to delete this book?",


### PR DESCRIPTION
将封面图片改为可点击区域，移除多余的查看按钮

- 将书籍封面图片区域改为可点击链接
- 添加悬停效果提升用户体验
- 移除冗余的"View"按钮，简化界面
- 封面图片和默认图标都可直接点击查看详情
- 潜在问题：用户可能不清楚封面可点击